### PR TITLE
[Bugfix] Fix Product carousel horizontal scroll

### DIFF
--- a/components/VerticalProductCarousel.tsx
+++ b/components/VerticalProductCarousel.tsx
@@ -12,7 +12,7 @@ const VerticalProductCarousel = ({
     <section className="flex flex-col items-center w-full lg:mt-4">
       <div className="h-[36rem] carousel carousel carousel-vertical gap-4 p-4 rounded-box bg-primary shadow-xl">
         {productsList?.map((product, idx) => (
-          <div className="carousel-item" id={`item${idx + 1}`} key={product.id}>
+          <div className="carousel-item" key={product.id}>
             <ProductCard product={product} />
           </div>
         ))}


### PR DESCRIPTION
Vertical and Horizontal carousels used the same ID resulting in elements with duplicate Ids on page and breaking anchor based scrolls.

This PR fixes horizontal carousel scrolling